### PR TITLE
Better split view handling

### DIFF
--- a/Sample App/JTSImageVC/JTSImageVC/JTSViewController.m
+++ b/Sample App/JTSImageVC/JTSImageVC/JTSViewController.m
@@ -46,7 +46,7 @@
     JTSImageViewController *imageViewer = [[JTSImageViewController alloc]
                                            initWithImageInfo:imageInfo
                                            mode:JTSImageViewControllerMode_Image
-                                           backgroundStyle:JTSImageViewControllerBackgroundOption_Scaled];
+                                           backgroundStyle:JTSImageViewControllerBackgroundOption_Blurred];
     
     // Present the view controller.
     [imageViewer showFromViewController:self transition:JTSImageViewControllerTransition_FromOriginalPosition];

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -1071,7 +1071,6 @@ typedef struct {
             [weakSelf.animationDelegate imageViewerWillAnimateDismissal:weakSelf withContainerView:weakSelf.view duration:duration];
         }
         
-//        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
         weakSelf.blackBackdrop.alpha = 0;
         weakSelf.view.alpha = 0;
         if ([UIApplication sharedApplication].jts_usesViewControllerBasedStatusBarAppearance) {
@@ -1110,7 +1109,6 @@ typedef struct {
             [weakSelf.animationDelegate imageViewerWillAnimateDismissal:weakSelf withContainerView:weakSelf.view duration:duration];
         }
         
-//        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
         weakSelf.blackBackdrop.alpha = 0;
         weakSelf.scrollView.alpha = 0;
         CGFloat scaling = JTSImageViewController_MaxScalingForExpandingOffscreenStyleTransition;
@@ -1160,7 +1158,6 @@ typedef struct {
             [weakSelf.animationDelegate imageViewerWillAnimateDismissal:weakSelf withContainerView:weakSelf.view duration:duration];
         }
         
-//        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
         weakSelf.blackBackdrop.alpha = 0;
         textViewSnapshot.alpha = 0;
         CGFloat targetScale = JTSImageViewController_MaxScalingForExpandingOffscreenStyleTransition;
@@ -1332,7 +1329,6 @@ typedef struct {
         }
     }
     
-//    self.snapshotView.center = CGPointMake(self.view.bounds.size.width/2.0f, self.view.bounds.size.height/2.0f);
     
     if (_flags.rotationTransformIsDirty) {
         _flags.rotationTransformIsDirty = NO;
@@ -1347,9 +1343,6 @@ typedef struct {
             } else {
                 targetScaling = JTSImageViewController_MinimumBackgroundScaling;
             }
-//            self.snapshotView.transform = CGAffineTransformConcat(transform, CGAffineTransformMakeScale(targetScaling, targetScaling));
-        } else {
-//            self.snapshotView.transform = transform;
         }
     }
 }

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -878,6 +878,7 @@ typedef struct {
     
     __weak JTSImageViewController *weakSelf = self;
     
+    self.textView.hidden = YES;
     [viewController presentViewController:weakSelf animated:NO completion:^{
         
         if ([UIApplication sharedApplication].statusBarOrientation != _startingInfo.startingInterfaceOrientation) {

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -441,7 +441,7 @@ typedef struct {
     self.scrollView.isAccessibilityElement = YES;
     self.scrollView.accessibilityLabel = self.accessibilityLabel;
     self.scrollView.accessibilityHint = [self accessibilityHintZoomedOut];
-    self.scrollView.backgroundColor = [UIColor blueColor];
+    self.scrollView.backgroundColor = [UIColor clearColor];
     [self.view addSubview:self.scrollView];
     
     
@@ -496,7 +496,7 @@ typedef struct {
 
 - (void)viewDidLoadForAltTextMode {
     
-    self.view.backgroundColor = [UIColor clearColor];
+    self.view.backgroundColor = [UIColor blackColor];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     
     self.blackBackdrop = [[UIView alloc] initWithFrame:CGRectInset(self.view.bounds, -512, -512)];

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -90,9 +90,9 @@ typedef struct {
 
 // Views
 @property (strong, nonatomic) UIView *progressContainer;
-@property (strong, nonatomic) UIView *outerContainerForScrollView;
-@property (strong, nonatomic) UIView *snapshotView;
-@property (strong, nonatomic) UIView *blurredSnapshotView;
+//@property (strong, nonatomic) UIView *outerContainerForScrollView;
+//@property (strong, nonatomic) UIView *snapshotView;
+//@property (strong, nonatomic) UIView *blurredSnapshotView;
 @property (strong, nonatomic) UIView *blackBackdrop;
 @property (strong, nonatomic) UIImageView *imageView;
 @property (strong, nonatomic) UIScrollView *scrollView;
@@ -281,6 +281,7 @@ typedef struct {
 }
 
 - (void)viewDidLoad {
+    self.modalPresentationStyle = UIModalPresentationCustom;
     [super viewDidLoad];
     if (self.mode == JTSImageViewControllerMode_Image) {
         [self viewDidLoadForImageMode];
@@ -424,13 +425,13 @@ typedef struct {
 
 - (void)viewDidLoadForImageMode {
     
-    self.view.backgroundColor = [UIColor blackColor];
+    self.view.backgroundColor = [UIColor clearColor];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     
-    self.blackBackdrop = [[UIView alloc] initWithFrame:CGRectInset(self.view.bounds, -512, -512)];
-    self.blackBackdrop.backgroundColor = [UIColor blackColor];
-    self.blackBackdrop.alpha = 0;
-    [self.view addSubview:self.blackBackdrop];
+//    self.blackBackdrop = [[UIView alloc] initWithFrame:CGRectInset(self.view.bounds, -512, -512)];
+//    self.blackBackdrop.backgroundColor = [UIColor clearColor];
+//    self.blackBackdrop.alpha = 0;
+//    [self.view addSubview:self.blackBackdrop];
     
     self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
     self.scrollView.delegate = self;
@@ -440,11 +441,13 @@ typedef struct {
     self.scrollView.isAccessibilityElement = YES;
     self.scrollView.accessibilityLabel = self.accessibilityLabel;
     self.scrollView.accessibilityHint = [self accessibilityHintZoomedOut];
+    self.scrollView.backgroundColor = [UIColor blueColor];
     [self.view addSubview:self.scrollView];
+    
     
     CGRect referenceFrameInWindow = [self.imageInfo.referenceView convertRect:self.imageInfo.referenceRect toView:nil];
     CGRect referenceFrameInMyView = [self.view convertRect:referenceFrameInWindow fromView:nil];
-    
+
     self.imageView = [[UIImageView alloc] initWithFrame:referenceFrameInMyView];
     self.imageView.layer.cornerRadius = self.imageInfo.referenceCornerRadius;
     self.imageView.contentMode = UIViewContentModeScaleAspectFill;
@@ -493,11 +496,11 @@ typedef struct {
 
 - (void)viewDidLoadForAltTextMode {
     
-    self.view.backgroundColor = [UIColor blackColor];
+    self.view.backgroundColor = [UIColor clearColor];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     
     self.blackBackdrop = [[UIView alloc] initWithFrame:CGRectInset(self.view.bounds, -512, -512)];
-    self.blackBackdrop.backgroundColor = [UIColor blackColor];
+    self.blackBackdrop.backgroundColor = [UIColor clearColor];
     self.blackBackdrop.alpha = 0;
     [self.view addSubview:self.blackBackdrop];
     
@@ -577,15 +580,15 @@ typedef struct {
     _flags.isAnimatingAPresentationOrDismissal = YES;
     self.view.userInteractionEnabled = NO;
     
-    self.snapshotView = [self snapshotFromParentmostViewController:viewController];
-    
-    if (self.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-        self.blurredSnapshotView = [self blurredSnapshotFromParentmostViewController:viewController];
-        [self.snapshotView addSubview:self.blurredSnapshotView];
-        self.blurredSnapshotView.alpha = 0;
-    }
-    
-    [self.view insertSubview:self.snapshotView atIndex:0];
+//    self.snapshotView = [self snapshotFromParentmostViewController:viewController];
+//    
+//    if (self.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
+//        self.blurredSnapshotView = [self blurredSnapshotFromParentmostViewController:viewController];
+//        [self.snapshotView addSubview:self.blurredSnapshotView];
+//        self.blurredSnapshotView.alpha = 0;
+//    }
+//    
+//    [self.view insertSubview:self.snapshotView atIndex:0];
     
     _startingInfo.startingInterfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
     
@@ -615,17 +618,17 @@ typedef struct {
         [self updateScrollViewAndImageViewForCurrentMetrics];
         
         BOOL mustRotateDuringTransition = ([UIApplication sharedApplication].statusBarOrientation != _startingInfo.startingInterfaceOrientation);
-        if (mustRotateDuringTransition) {
-            CGRect newStartingRect = [self.snapshotView convertRect:_startingInfo.startingReferenceFrameForThumbnail toView:self.view];
-            self.imageView.frame = newStartingRect;
-            [self updateScrollViewAndImageViewForCurrentMetrics];
-            self.imageView.transform = self.snapshotView.transform;
-            CGPoint centerInRect = CGPointMake(_startingInfo.startingReferenceFrameForThumbnail.origin.x
-                                               +_startingInfo.startingReferenceFrameForThumbnail.size.width/2.0f,
-                                               _startingInfo.startingReferenceFrameForThumbnail.origin.y
-                                               +_startingInfo.startingReferenceFrameForThumbnail.size.height/2.0f);
-            self.imageView.center = centerInRect;
-        }
+//        if (mustRotateDuringTransition) {
+//            CGRect newStartingRect = [self.snapshotView convertRect:_startingInfo.startingReferenceFrameForThumbnail toView:self.view];
+//            self.imageView.frame = newStartingRect;
+//            [self updateScrollViewAndImageViewForCurrentMetrics];
+//            self.imageView.transform = self.snapshotView.transform;
+//            CGPoint centerInRect = CGPointMake(_startingInfo.startingReferenceFrameForThumbnail.origin.x
+//                                               +_startingInfo.startingReferenceFrameForThumbnail.size.width/2.0f,
+//                                               _startingInfo.startingReferenceFrameForThumbnail.origin.y
+//                                               +_startingInfo.startingReferenceFrameForThumbnail.size.height/2.0f);
+//            self.imageView.center = centerInRect;
+//        }
         
         if ([self.optionsDelegate respondsToSelector:@selector(imageViewerShouldFadeThumbnailsDuringPresentationAndDismissal:)]) {
             if ([self.optionsDelegate imageViewerShouldFadeThumbnailsDuringPresentationAndDismissal:self]) {
@@ -695,10 +698,10 @@ typedef struct {
                      } else {
                          scaling = JTSImageViewController_MinimumBackgroundScaling;
                      }
-                     weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(scaling, scaling));
+//                     weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(scaling, scaling));
                      
                      if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-                         weakSelf.blurredSnapshotView.alpha = 1;
+//                         weakSelf.blurredSnapshotView.alpha = 1;
                      }
                      
                      if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Scaled) {
@@ -754,15 +757,15 @@ typedef struct {
     _flags.isAnimatingAPresentationOrDismissal = YES;
     self.view.userInteractionEnabled = NO;
     
-    self.snapshotView = [self snapshotFromParentmostViewController:viewController];
+//    self.snapshotView = [self snapshotFromParentmostViewController:viewController];
+//    
+//    if (self.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
+//        self.blurredSnapshotView = [self blurredSnapshotFromParentmostViewController:viewController];
+//        [self.snapshotView addSubview:self.blurredSnapshotView];
+//        self.blurredSnapshotView.alpha = 0;
+//    }
     
-    if (self.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-        self.blurredSnapshotView = [self blurredSnapshotFromParentmostViewController:viewController];
-        [self.snapshotView addSubview:self.blurredSnapshotView];
-        self.blurredSnapshotView.alpha = 0;
-    }
-    
-    [self.view insertSubview:self.snapshotView atIndex:0];
+//    [self.view insertSubview:self.snapshotView atIndex:0];
     _startingInfo.startingInterfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
     self.lastUsedOrientation = [UIApplication sharedApplication].statusBarOrientation;
     CGRect referenceFrameInWindow = [self.imageInfo.referenceView convertRect:self.imageInfo.referenceRect toView:nil];
@@ -822,10 +825,10 @@ typedef struct {
                  } else {
                      targetScaling = JTSImageViewController_MinimumBackgroundScaling;
                  }
-                 weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(targetScaling, targetScaling));
+//                 weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(targetScaling, targetScaling));
                  
                  if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-                     weakSelf.blurredSnapshotView.alpha = 1;
+//                     weakSelf.blurredSnapshotView.alpha = 1;
                  }
                  
                  if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Scaled) {
@@ -858,15 +861,15 @@ typedef struct {
     _flags.isAnimatingAPresentationOrDismissal = YES;
     self.view.userInteractionEnabled = NO;
     
-    self.snapshotView = [self snapshotFromParentmostViewController:viewController];
-    
-    if (self.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-        self.blurredSnapshotView = [self blurredSnapshotFromParentmostViewController:viewController];
-        [self.snapshotView addSubview:self.blurredSnapshotView];
-        self.blurredSnapshotView.alpha = 0;
-    }
-    
-    [self.view insertSubview:self.snapshotView atIndex:0];
+//    self.snapshotView = [self snapshotFromParentmostViewController:viewController];
+//    
+//    if (self.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
+//        self.blurredSnapshotView = [self blurredSnapshotFromParentmostViewController:viewController];
+//        [self.snapshotView addSubview:self.blurredSnapshotView];
+//        self.blurredSnapshotView.alpha = 0;
+//    }
+//    
+//    [self.view insertSubview:self.snapshotView atIndex:0];
     _startingInfo.startingInterfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
     self.lastUsedOrientation = [UIApplication sharedApplication].statusBarOrientation;
     CGRect referenceFrameInWindow = [self.imageInfo.referenceView convertRect:self.imageInfo.referenceRect toView:nil];
@@ -930,10 +933,10 @@ typedef struct {
                  } else {
                      targetScaling = JTSImageViewController_MinimumBackgroundScaling;
                  }
-                 weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(targetScaling, targetScaling));
+//                 weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(targetScaling, targetScaling));
                  
                  if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-                     weakSelf.blurredSnapshotView.alpha = 1;
+//                     weakSelf.blurredSnapshotView.alpha = 1;
                  }
                  
                  if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Scaled) {
@@ -1057,33 +1060,33 @@ typedef struct {
                     [weakSelf.animationDelegate imageViewerWillAnimateDismissal:weakSelf withContainerView:weakSelf.view duration:duration];
                 }
                 
-                weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
+//                weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
                 [weakSelf removeMotionEffectsFromSnapshotView];
                 weakSelf.blackBackdrop.alpha = 0;
                 
                 if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-                    weakSelf.blurredSnapshotView.alpha = 0;
+//                    weakSelf.blurredSnapshotView.alpha = 0;
                 }
                 
                 BOOL mustRotateDuringTransition = ([UIApplication sharedApplication].statusBarOrientation != _startingInfo.startingInterfaceOrientation);
                 if (mustRotateDuringTransition) {
-                    CGRect newEndingRect;
-                    CGPoint centerInRect;
-                    if (_startingInfo.presentingViewControllerPresentedFromItsUnsupportedOrientation) {
-                        CGRect rectToConvert = _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation;
-                        CGRect rectForCentering = [weakSelf.snapshotView convertRect:rectToConvert toView:weakSelf.view];
-                        centerInRect = CGPointMake(rectForCentering.origin.x+rectForCentering.size.width/2.0f,
-                                                   rectForCentering.origin.y+rectForCentering.size.height/2.0f);
-                        newEndingRect = _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation;
-                    } else {
-                        newEndingRect = _startingInfo.startingReferenceFrameForThumbnail;
-                        CGRect rectForCentering = [weakSelf.snapshotView convertRect:_startingInfo.startingReferenceFrameForThumbnail toView:weakSelf.view];
-                        centerInRect = CGPointMake(rectForCentering.origin.x+rectForCentering.size.width/2.0f,
-                                                   rectForCentering.origin.y+rectForCentering.size.height/2.0f);
-                    }
-                    weakSelf.imageView.frame = newEndingRect;
-                    weakSelf.imageView.transform = weakSelf.currentSnapshotRotationTransform;
-                    weakSelf.imageView.center = centerInRect;
+//                    CGRect newEndingRect;
+//                    CGPoint centerInRect;
+//                    if (_startingInfo.presentingViewControllerPresentedFromItsUnsupportedOrientation) {
+//                        CGRect rectToConvert = _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation;
+//                        CGRect rectForCentering = [weakSelf.snapshotView convertRect:rectToConvert toView:weakSelf.view];
+//                        centerInRect = CGPointMake(rectForCentering.origin.x+rectForCentering.size.width/2.0f,
+//                                                   rectForCentering.origin.y+rectForCentering.size.height/2.0f);
+//                        newEndingRect = _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation;
+//                    } else {
+//                        newEndingRect = _startingInfo.startingReferenceFrameForThumbnail;
+//                        CGRect rectForCentering = [weakSelf.snapshotView convertRect:_startingInfo.startingReferenceFrameForThumbnail toView:weakSelf.view];
+//                        centerInRect = CGPointMake(rectForCentering.origin.x+rectForCentering.size.width/2.0f,
+//                                                   rectForCentering.origin.y+rectForCentering.size.height/2.0f);
+//                    }
+//                    weakSelf.imageView.frame = newEndingRect;
+//                    weakSelf.imageView.transform = weakSelf.currentSnapshotRotationTransform;
+//                    weakSelf.imageView.center = centerInRect;
                 } else {
                     if (_startingInfo.presentingViewControllerPresentedFromItsUnsupportedOrientation) {
                         weakSelf.imageView.frame = _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation;
@@ -1133,18 +1136,20 @@ typedef struct {
     }
     
     [UIView animateWithDuration:duration delay:0 options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseInOut animations:^{
-        
+
+        weakSelf.view.alpha = 0;
+
         if ([weakSelf.animationDelegate respondsToSelector:@selector(imageViewerWillAnimateDismissal:withContainerView:duration:)]) {
             [weakSelf.animationDelegate imageViewerWillAnimateDismissal:weakSelf withContainerView:weakSelf.view duration:duration];
         }
         
-        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
+//        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
         [weakSelf removeMotionEffectsFromSnapshotView];
         weakSelf.blackBackdrop.alpha = 0;
-        if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-            weakSelf.blurredSnapshotView.alpha = 0;
-        }
-        weakSelf.scrollView.alpha = 0;
+//        if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
+//            weakSelf.blurredSnapshotView.alpha = 0;
+//        }
+        weakSelf.view.alpha = 0;
         if ([UIApplication sharedApplication].jts_usesViewControllerBasedStatusBarAppearance) {
             [weakSelf setNeedsStatusBarAppearanceUpdate];
         } else {
@@ -1181,11 +1186,11 @@ typedef struct {
             [weakSelf.animationDelegate imageViewerWillAnimateDismissal:weakSelf withContainerView:weakSelf.view duration:duration];
         }
         
-        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
+//        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
         [weakSelf removeMotionEffectsFromSnapshotView];
         weakSelf.blackBackdrop.alpha = 0;
         if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-            weakSelf.blurredSnapshotView.alpha = 0;
+//            weakSelf.blurredSnapshotView.alpha = 0;
         }
         weakSelf.scrollView.alpha = 0;
         CGFloat scaling = JTSImageViewController_MaxScalingForExpandingOffscreenStyleTransition;
@@ -1235,12 +1240,12 @@ typedef struct {
             [weakSelf.animationDelegate imageViewerWillAnimateDismissal:weakSelf withContainerView:weakSelf.view duration:duration];
         }
         
-        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
+//        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
         [weakSelf removeMotionEffectsFromSnapshotView];
         weakSelf.blackBackdrop.alpha = 0;
         textViewSnapshot.alpha = 0;
         if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-            weakSelf.blurredSnapshotView.alpha = 0;
+//            weakSelf.blurredSnapshotView.alpha = 0;
         }
         CGFloat targetScale = JTSImageViewController_MaxScalingForExpandingOffscreenStyleTransition;
         textViewSnapshot.transform = CGAffineTransformMakeScale(targetScale, targetScale);
@@ -1301,7 +1306,7 @@ typedef struct {
     UIImageView *imageView = [[UIImageView alloc] initWithFrame:contextBounds];
     imageView.image = blurredImage;
     imageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-    imageView.backgroundColor = [UIColor blackColor];
+    imageView.backgroundColor = [UIColor clearColor];
     
     return imageView;
 }
@@ -1321,13 +1326,13 @@ typedef struct {
     
     UIMotionEffectGroup *effectGroup = [[UIMotionEffectGroup alloc] init];
     effectGroup.motionEffects = @[horizontalEffect, verticalEffect];
-    [self.snapshotView addMotionEffect:effectGroup];
+//    [self.snapshotView addMotionEffect:effectGroup];
 }
 
 - (void)removeMotionEffectsFromSnapshotView {
-    for (UIMotionEffect *effect in self.snapshotView.motionEffects) {
-        [self.snapshotView removeMotionEffect:effect];
-    }
+//    for (UIMotionEffect *effect in self.snapshotView.motionEffects) {
+////        [self.snapshotView removeMotionEffect:effect];
+//    }
 }
 
 #pragma mark - Interface Updates
@@ -1435,7 +1440,7 @@ typedef struct {
         }
     }
     
-    self.snapshotView.center = CGPointMake(self.view.bounds.size.width/2.0f, self.view.bounds.size.height/2.0f);
+//    self.snapshotView.center = CGPointMake(self.view.bounds.size.width/2.0f, self.view.bounds.size.height/2.0f);
     
     if (_flags.rotationTransformIsDirty) {
         _flags.rotationTransformIsDirty = NO;
@@ -1450,9 +1455,9 @@ typedef struct {
             } else {
                 targetScaling = JTSImageViewController_MinimumBackgroundScaling;
             }
-            self.snapshotView.transform = CGAffineTransformConcat(transform, CGAffineTransformMakeScale(targetScaling, targetScaling));
+//            self.snapshotView.transform = CGAffineTransformConcat(transform, CGAffineTransformMakeScale(targetScaling, targetScaling));
         } else {
-            self.snapshotView.transform = transform;
+//            self.snapshotView.transform = transform;
         }
     }
 }

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -25,7 +25,7 @@ CG_INLINE CGFLOAT_TYPE JTSImageFloatAbs(CGFLOAT_TYPE aFloat) {
 ///--------------------------------------------------------------------------------------------------------------------
 
 // Public Constants
-CGFloat const JTSImageViewController_DefaultAlphaForBackgroundDimmingOverlay = 0.66f;
+CGFloat const JTSImageViewController_DefaultAlphaForBackgroundDimmingOverlay = 0.80f;
 CGFloat const JTSImageViewController_DefaultBackgroundBlurRadius = 2.0f;
 
 // Private Constants
@@ -90,9 +90,6 @@ typedef struct {
 
 // Views
 @property (strong, nonatomic) UIView *progressContainer;
-//@property (strong, nonatomic) UIView *outerContainerForScrollView;
-//@property (strong, nonatomic) UIView *snapshotView;
-//@property (strong, nonatomic) UIView *blurredSnapshotView;
 @property (strong, nonatomic) UIView *blackBackdrop;
 @property (strong, nonatomic) UIImageView *imageView;
 @property (strong, nonatomic) UIScrollView *scrollView;
@@ -581,16 +578,6 @@ typedef struct {
     _flags.isAnimatingAPresentationOrDismissal = YES;
     self.view.userInteractionEnabled = NO;
     
-//    self.snapshotView = [self snapshotFromParentmostViewController:viewController];
-//    
-//    if (self.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//        self.blurredSnapshotView = [self blurredSnapshotFromParentmostViewController:viewController];
-//        [self.snapshotView addSubview:self.blurredSnapshotView];
-//        self.blurredSnapshotView.alpha = 0;
-//    }
-//    
-//    [self.view insertSubview:self.snapshotView atIndex:0];
-    
     _startingInfo.startingInterfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
     
     self.lastUsedOrientation = [UIApplication sharedApplication].statusBarOrientation;
@@ -617,19 +604,6 @@ typedef struct {
         self.imageView.frame = referenceFrameInMyView;
         self.imageView.layer.cornerRadius = self.imageInfo.referenceCornerRadius;
         [self updateScrollViewAndImageViewForCurrentMetrics];
-        
-        BOOL mustRotateDuringTransition = ([UIApplication sharedApplication].statusBarOrientation != _startingInfo.startingInterfaceOrientation);
-//        if (mustRotateDuringTransition) {
-//            CGRect newStartingRect = [self.snapshotView convertRect:_startingInfo.startingReferenceFrameForThumbnail toView:self.view];
-//            self.imageView.frame = newStartingRect;
-//            [self updateScrollViewAndImageViewForCurrentMetrics];
-//            self.imageView.transform = self.snapshotView.transform;
-//            CGPoint centerInRect = CGPointMake(_startingInfo.startingReferenceFrameForThumbnail.origin.x
-//                                               +_startingInfo.startingReferenceFrameForThumbnail.size.width/2.0f,
-//                                               _startingInfo.startingReferenceFrameForThumbnail.origin.y
-//                                               +_startingInfo.startingReferenceFrameForThumbnail.size.height/2.0f);
-//            self.imageView.center = centerInRect;
-//        }
         
         if ([self.optionsDelegate respondsToSelector:@selector(imageViewerShouldFadeThumbnailsDuringPresentationAndDismissal:)]) {
             if ([self.optionsDelegate imageViewerShouldFadeThumbnailsDuringPresentationAndDismissal:self]) {
@@ -699,20 +673,8 @@ typedef struct {
                      } else {
                          scaling = JTSImageViewController_MinimumBackgroundScaling;
                      }
-//                     weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(scaling, scaling));
                      
-                     if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//                         weakSelf.blurredSnapshotView.alpha = 1;
-                     }
-                     
-                     if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Scaled) {
-                         [weakSelf addMotionEffectsToSnapshotView];
-                     }
                      weakSelf.blackBackdrop.alpha = self.alphaForBackgroundDimmingOverlay;
-                     
-                     if (mustRotateDuringTransition) {
-                         weakSelf.imageView.transform = CGAffineTransformIdentity;
-                     }
                      
                      CGRect endFrameForImageView;
                      if (weakSelf.image) {
@@ -826,15 +788,7 @@ typedef struct {
                  } else {
                      targetScaling = JTSImageViewController_MinimumBackgroundScaling;
                  }
-//                 weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(targetScaling, targetScaling));
                  
-                 if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//                     weakSelf.blurredSnapshotView.alpha = 1;
-                 }
-                 
-                 if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Scaled) {
-                     [weakSelf addMotionEffectsToSnapshotView];
-                 }
                  weakSelf.blackBackdrop.alpha = self.alphaForBackgroundDimmingOverlay;
                  
                  weakSelf.scrollView.alpha = 1.0f;
@@ -935,15 +889,7 @@ typedef struct {
                  } else {
                      targetScaling = JTSImageViewController_MinimumBackgroundScaling;
                  }
-//                 weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(targetScaling, targetScaling));
                  
-                 if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//                     weakSelf.blurredSnapshotView.alpha = 1;
-                 }
-                 
-                 if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Scaled) {
-                     [weakSelf addMotionEffectsToSnapshotView];
-                 }
                  weakSelf.blackBackdrop.alpha = self.alphaForBackgroundDimmingOverlay;
                  
                  textViewSnapshot.alpha = 1.0;
@@ -1062,47 +1008,24 @@ typedef struct {
                     [weakSelf.animationDelegate imageViewerWillAnimateDismissal:weakSelf withContainerView:weakSelf.view duration:duration];
                 }
                 
-//                weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
-                [weakSelf removeMotionEffectsFromSnapshotView];
                 weakSelf.blackBackdrop.alpha = 0;
                 
                 if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
 //                    weakSelf.blurredSnapshotView.alpha = 0;
                 }
                 
-                BOOL mustRotateDuringTransition = ([UIApplication sharedApplication].statusBarOrientation != _startingInfo.startingInterfaceOrientation);
-                if (mustRotateDuringTransition) {
-//                    CGRect newEndingRect;
-//                    CGPoint centerInRect;
-//                    if (_startingInfo.presentingViewControllerPresentedFromItsUnsupportedOrientation) {
-//                        CGRect rectToConvert = _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation;
-//                        CGRect rectForCentering = [weakSelf.snapshotView convertRect:rectToConvert toView:weakSelf.view];
-//                        centerInRect = CGPointMake(rectForCentering.origin.x+rectForCentering.size.width/2.0f,
-//                                                   rectForCentering.origin.y+rectForCentering.size.height/2.0f);
-//                        newEndingRect = _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation;
-//                    } else {
-//                        newEndingRect = _startingInfo.startingReferenceFrameForThumbnail;
-//                        CGRect rectForCentering = [weakSelf.snapshotView convertRect:_startingInfo.startingReferenceFrameForThumbnail toView:weakSelf.view];
-//                        centerInRect = CGPointMake(rectForCentering.origin.x+rectForCentering.size.width/2.0f,
-//                                                   rectForCentering.origin.y+rectForCentering.size.height/2.0f);
-//                    }
-//                    weakSelf.imageView.frame = newEndingRect;
-//                    weakSelf.imageView.transform = weakSelf.currentSnapshotRotationTransform;
-//                    weakSelf.imageView.center = centerInRect;
+                if (_startingInfo.presentingViewControllerPresentedFromItsUnsupportedOrientation) {
+                    weakSelf.imageView.frame = _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation;
                 } else {
-                    if (_startingInfo.presentingViewControllerPresentedFromItsUnsupportedOrientation) {
-                        weakSelf.imageView.frame = _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation;
-                    } else {
-                        weakSelf.imageView.frame = _startingInfo.startingReferenceFrameForThumbnail;
-                    }
-                    
-                    // Rotation not needed, so fade the status bar back in. Looks nicer.
-                    if ([UIApplication sharedApplication].jts_usesViewControllerBasedStatusBarAppearance) {
-                        [weakSelf setNeedsStatusBarAppearanceUpdate];
-                    } else {
-                        [[UIApplication sharedApplication] setStatusBarHidden:_startingInfo.statusBarHiddenPriorToPresentation
-                                                                withAnimation:UIStatusBarAnimationFade];
-                    }
+                    weakSelf.imageView.frame = _startingInfo.startingReferenceFrameForThumbnail;
+                }
+                
+                // Rotation not needed, so fade the status bar back in. Looks nicer.
+                if ([UIApplication sharedApplication].jts_usesViewControllerBasedStatusBarAppearance) {
+                    [weakSelf setNeedsStatusBarAppearanceUpdate];
+                } else {
+                    [[UIApplication sharedApplication] setStatusBarHidden:_startingInfo.statusBarHiddenPriorToPresentation
+                                                            withAnimation:UIStatusBarAnimationFade];
                 }
             } completion:^(BOOL finished) {
                 
@@ -1146,11 +1069,7 @@ typedef struct {
         }
         
 //        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
-        [weakSelf removeMotionEffectsFromSnapshotView];
         weakSelf.blackBackdrop.alpha = 0;
-//        if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//            weakSelf.blurredSnapshotView.alpha = 0;
-//        }
         weakSelf.view.alpha = 0;
         if ([UIApplication sharedApplication].jts_usesViewControllerBasedStatusBarAppearance) {
             [weakSelf setNeedsStatusBarAppearanceUpdate];
@@ -1189,11 +1108,7 @@ typedef struct {
         }
         
 //        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
-        [weakSelf removeMotionEffectsFromSnapshotView];
         weakSelf.blackBackdrop.alpha = 0;
-        if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//            weakSelf.blurredSnapshotView.alpha = 0;
-        }
         weakSelf.scrollView.alpha = 0;
         CGFloat scaling = JTSImageViewController_MaxScalingForExpandingOffscreenStyleTransition;
         weakSelf.scrollView.transform = CGAffineTransformMakeScale(scaling, scaling);
@@ -1243,12 +1158,8 @@ typedef struct {
         }
         
 //        weakSelf.snapshotView.transform = weakSelf.currentSnapshotRotationTransform;
-        [weakSelf removeMotionEffectsFromSnapshotView];
         weakSelf.blackBackdrop.alpha = 0;
         textViewSnapshot.alpha = 0;
-        if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//            weakSelf.blurredSnapshotView.alpha = 0;
-        }
         CGFloat targetScale = JTSImageViewController_MaxScalingForExpandingOffscreenStyleTransition;
         textViewSnapshot.transform = CGAffineTransformMakeScale(targetScale, targetScale);
         if ([UIApplication sharedApplication].jts_usesViewControllerBasedStatusBarAppearance) {
@@ -1311,30 +1222,6 @@ typedef struct {
     imageView.backgroundColor = [UIColor clearColor];
     
     return imageView;
-}
-
-#pragma mark - Motion Effects
-
-- (void)addMotionEffectsToSnapshotView {
-    UIInterpolatingMotionEffect *verticalEffect;
-    verticalEffect = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y" type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
-    verticalEffect.minimumRelativeValue = @(12);
-    verticalEffect.maximumRelativeValue = @(-12);
-    
-    UIInterpolatingMotionEffect *horizontalEffect;
-    horizontalEffect = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x" type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
-    horizontalEffect.minimumRelativeValue = @(12);
-    horizontalEffect.maximumRelativeValue = @(-12);
-    
-    UIMotionEffectGroup *effectGroup = [[UIMotionEffectGroup alloc] init];
-    effectGroup.motionEffects = @[horizontalEffect, verticalEffect];
-//    [self.snapshotView addMotionEffect:effectGroup];
-}
-
-- (void)removeMotionEffectsFromSnapshotView {
-//    for (UIMotionEffect *effect in self.snapshotView.motionEffects) {
-////        [self.snapshotView removeMotionEffect:effect];
-//    }
 }
 
 #pragma mark - Interface Updates

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -496,7 +496,7 @@ typedef struct {
 }
 
 - (void)viewDidLoadForAltTextMode {
-    
+    self.view.alpha = 0.0;
     self.view.backgroundColor = [UIColor blackColor];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     
@@ -700,16 +700,9 @@ typedef struct {
                      } else {
                          scaling = JTSImageViewController_MinimumBackgroundScaling;
                      }
-//                     weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(scaling, scaling));
                      
-                     if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//                         weakSelf.blurredSnapshotView.alpha = 1;
-                     }
-                     
-                     if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Scaled) {
-                         [weakSelf addMotionEffectsToSnapshotView];
-                     }
                      weakSelf.blackBackdrop.alpha = self.alphaForBackgroundDimmingOverlay;
+                     weakSelf.view.alpha = 1.0;
                      
                      if (mustRotateDuringTransition) {
                          weakSelf.imageView.transform = CGAffineTransformIdentity;

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -430,7 +430,7 @@ typedef struct {
     
     self.blackBackdrop = [[UIView alloc] initWithFrame:self.view.bounds];
     self.blackBackdrop.backgroundColor = [UIColor blackColor];
-    self.blackBackdrop.alpha = [self alphaForBackgroundDimmingOverlay];
+    self.blackBackdrop.alpha = 0.0;
     self.blackBackdrop.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self.view addSubview:self.blackBackdrop];
     
@@ -502,7 +502,7 @@ typedef struct {
     
     self.blackBackdrop = [[UIView alloc] initWithFrame:CGRectInset(self.view.bounds, -512, -512)];
     self.blackBackdrop.backgroundColor = [UIColor clearColor];
-    self.blackBackdrop.alpha = [self alphaForBackgroundDimmingOverlay];
+    self.blackBackdrop.alpha = 0.0;
     self.blackBackdrop.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self.view addSubview:self.blackBackdrop];
     

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -500,7 +500,7 @@ typedef struct {
     self.view.backgroundColor = [UIColor blackColor];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     
-    self.blackBackdrop = [[UIView alloc] initWithFrame:CGRectInset(self.view.bounds, -512, -512)];
+    self.blackBackdrop = [[UIView alloc] initWithFrame:self.view.bounds];
     self.blackBackdrop.backgroundColor = [UIColor clearColor];
     self.blackBackdrop.alpha = 0.0;
     self.blackBackdrop.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -723,15 +723,6 @@ typedef struct {
     _flags.isAnimatingAPresentationOrDismissal = YES;
     self.view.userInteractionEnabled = NO;
     
-//    self.snapshotView = [self snapshotFromParentmostViewController:viewController];
-//    
-//    if (self.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//        self.blurredSnapshotView = [self blurredSnapshotFromParentmostViewController:viewController];
-//        [self.snapshotView addSubview:self.blurredSnapshotView];
-//        self.blurredSnapshotView.alpha = 0;
-//    }
-    
-//    [self.view insertSubview:self.snapshotView atIndex:0];
     _startingInfo.startingInterfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
     self.lastUsedOrientation = [UIApplication sharedApplication].statusBarOrientation;
     CGRect referenceFrameInWindow = [self.imageInfo.referenceView convertRect:self.imageInfo.referenceRect toView:nil];
@@ -819,15 +810,6 @@ typedef struct {
     _flags.isAnimatingAPresentationOrDismissal = YES;
     self.view.userInteractionEnabled = NO;
     
-//    self.snapshotView = [self snapshotFromParentmostViewController:viewController];
-//    
-//    if (self.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//        self.blurredSnapshotView = [self blurredSnapshotFromParentmostViewController:viewController];
-//        [self.snapshotView addSubview:self.blurredSnapshotView];
-//        self.blurredSnapshotView.alpha = 0;
-//    }
-//    
-//    [self.view insertSubview:self.snapshotView atIndex:0];
     _startingInfo.startingInterfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
     self.lastUsedOrientation = [UIApplication sharedApplication].statusBarOrientation;
     CGRect referenceFrameInWindow = [self.imageInfo.referenceView convertRect:self.imageInfo.referenceRect toView:nil];
@@ -1014,10 +996,6 @@ typedef struct {
                 }
                 
                 weakSelf.blackBackdrop.alpha = 0;
-                
-                if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
-//                    weakSelf.blurredSnapshotView.alpha = 0;
-                }
                 
                 if (_startingInfo.presentingViewControllerPresentedFromItsUnsupportedOrientation) {
                     weakSelf.imageView.frame = _startingInfo.startingReferenceFrameForThumbnailInPresentingViewControllersOriginalOrientation;

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -920,8 +920,10 @@ typedef struct {
     
     if ([self.optionsDelegate respondsToSelector:@selector(alphaForBackgroundDimmingOverlayInImageViewer:)]) {
         alpha = [self.optionsDelegate alphaForBackgroundDimmingOverlayInImageViewer:self];
-    } else {
+    } else if (_mode == JTSImageViewControllerMode_Image){
         alpha = JTSImageViewController_DefaultAlphaForBackgroundDimmingOverlay;
+    } else {
+        alpha = 1.0;
     }
     
     return alpha;

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -500,7 +500,7 @@ typedef struct {
     self.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     
     self.blackBackdrop = [[UIView alloc] initWithFrame:self.view.bounds];
-    self.blackBackdrop.backgroundColor = [UIColor clearColor];
+    self.blackBackdrop.backgroundColor = [UIColor blackColor];
     self.blackBackdrop.alpha = 0.0;
     self.blackBackdrop.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self.view addSubview:self.blackBackdrop];

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -428,10 +428,11 @@ typedef struct {
     self.view.backgroundColor = [UIColor clearColor];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     
-//    self.blackBackdrop = [[UIView alloc] initWithFrame:CGRectInset(self.view.bounds, -512, -512)];
-//    self.blackBackdrop.backgroundColor = [UIColor clearColor];
-//    self.blackBackdrop.alpha = 0;
-//    [self.view addSubview:self.blackBackdrop];
+    self.blackBackdrop = [[UIView alloc] initWithFrame:self.view.bounds];
+    self.blackBackdrop.backgroundColor = [UIColor blackColor];
+    self.blackBackdrop.alpha = [self alphaForBackgroundDimmingOverlay];
+    self.blackBackdrop.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    [self.view addSubview:self.blackBackdrop];
     
     self.scrollView = [[UIScrollView alloc] initWithFrame:self.view.bounds];
     self.scrollView.delegate = self;
@@ -501,7 +502,8 @@ typedef struct {
     
     self.blackBackdrop = [[UIView alloc] initWithFrame:CGRectInset(self.view.bounds, -512, -512)];
     self.blackBackdrop.backgroundColor = [UIColor clearColor];
-    self.blackBackdrop.alpha = 0;
+    self.blackBackdrop.alpha = [self alphaForBackgroundDimmingOverlay];
+    self.blackBackdrop.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self.view addSubview:self.blackBackdrop];
     
     CGFloat outerMargin = ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) ? 80.0 : 40.0;

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -496,8 +496,7 @@ typedef struct {
 }
 
 - (void)viewDidLoadForAltTextMode {
-    self.view.alpha = 0.0;
-    self.view.backgroundColor = [UIColor blackColor];
+    self.view.backgroundColor = [UIColor clearColor];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     
     self.blackBackdrop = [[UIView alloc] initWithFrame:self.view.bounds];
@@ -700,9 +699,16 @@ typedef struct {
                      } else {
                          scaling = JTSImageViewController_MinimumBackgroundScaling;
                      }
+//                     weakSelf.snapshotView.transform = CGAffineTransformConcat(weakSelf.snapshotView.transform, CGAffineTransformMakeScale(scaling, scaling));
                      
+                     if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Blurred) {
+//                         weakSelf.blurredSnapshotView.alpha = 1;
+                     }
+                     
+                     if (weakSelf.backgroundOptions & JTSImageViewControllerBackgroundOption_Scaled) {
+                         [weakSelf addMotionEffectsToSnapshotView];
+                     }
                      weakSelf.blackBackdrop.alpha = self.alphaForBackgroundDimmingOverlay;
-                     weakSelf.view.alpha = 1.0;
                      
                      if (mustRotateDuringTransition) {
                          weakSelf.imageView.transform = CGAffineTransformIdentity;

--- a/Source/JTSImageViewControllerObj.m
+++ b/Source/JTSImageViewControllerObj.m
@@ -88,6 +88,8 @@ typedef struct {
 @property (assign, nonatomic) UIInterfaceOrientation lastUsedOrientation;
 @property (assign, nonatomic) CGAffineTransform currentSnapshotRotationTransform;
 
+@property (assign, nonatomic) BOOL didChangeSize;
+
 // Views
 @property (strong, nonatomic) UIView *progressContainer;
 @property (strong, nonatomic) UIView *blackBackdrop;
@@ -136,6 +138,7 @@ typedef struct {
         _currentSnapshotRotationTransform = CGAffineTransformIdentity;
         _mode = mode;
         _backgroundOptions = backgroundOptions;
+        _didChangeSize = NO;
         if (_mode == JTSImageViewControllerMode_Image) {
             [self setupImageAndDownloadIfNecessary:imageInfo];
         }
@@ -186,7 +189,8 @@ typedef struct {
             BOOL startingRectForThumbnailIsNonZero = (CGRectEqualToRect(CGRectZero, _startingInfo.startingReferenceFrameForThumbnail) == NO);
             BOOL useCollapsingThumbnailStyle = (startingRectForThumbnailIsNonZero
                                                 && self.image != nil
-                                                && self.transition != JTSImageViewControllerTransition_FromOffscreen);
+                                                && self.transition != JTSImageViewControllerTransition_FromOffscreen
+                                                && !_didChangeSize);
             if (useCollapsingThumbnailStyle) {
                 [self dismissByCollapsingImageBackToOriginalPosition];
             } else {
@@ -321,10 +325,10 @@ typedef struct {
     });
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_7_1
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     _flags.rotationTransformIsDirty = YES;
     _flags.isRotating = YES;
+    _didChangeSize = YES;
     typeof(self) __weak weakSelf = self;
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         typeof(self) strongSelf = weakSelf;
@@ -340,7 +344,6 @@ typedef struct {
     }];
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 }
-#endif
 
 - (void)deviceOrientationDidChange:(NSNotification *)notification {
     


### PR DESCRIPTION
Better handling of iPad split view, specifically:
* Removed snapshot images and made the image view controller translucent. This allows for more easily handling the app being resized.
* If the view changed size, do not try to animate dismissing the image back to its source rect.